### PR TITLE
Make the dropdowns centre-aligned

### DIFF
--- a/users/templates/users/signup.html
+++ b/users/templates/users/signup.html
@@ -42,10 +42,10 @@
                 empIdField.style.display = 'none';
                 rollNumberField.style.display = 'block';
                 yearOfJoiningField.style.display = 'block';
-                programField.style.display = 'block';
-                disciplineField.style.display = 'block';
-                genderField.style.display = 'block';
-                hostelField.style.display = 'block';
+                programField.style.display = 'inline';
+                disciplineField.style.display = 'inline';
+                genderField.style.display = 'inline';
+                hostelField.style.display = 'inline';
             } else if (this.value === 'AA') {
                 empIdField.style.display = 'block';
                 rollNumberField.style.display = 'none';


### PR DESCRIPTION
Fixes #18 
Changes: The dropdowns in student sign up page after switching back and forth from student to authority to student sign up page remain centre-aligned.

Screenshots for the change: 
- Before
![screenshot from 2018-12-07 11-35-22](https://user-images.githubusercontent.com/38394281/49631828-8ce8e600-fa19-11e8-9fa9-c341ccffe125.png)

- After
![screenshot from 2018-12-07 11-31-50](https://user-images.githubusercontent.com/38394281/49631847-9bcf9880-fa19-11e8-8cc2-834fcfee4da4.png)

