### PR TITLE
feat: Add section for adding comments

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 
-from app.models import Leave, LeaveApprovingFaculty, LeaveApprovingWarden
+from app.models import Leave, LeaveApprovingFaculty, LeaveApprovingWarden,Comment
 
 admin.site.register(Leave)
 admin.site.register(LeaveApprovingFaculty)
 admin.site.register(LeaveApprovingWarden)
+admin.site.register(Comment)

--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.db.models import CASCADE
 from users.models import ProgramType, DisciplineType, HostelType
 import enum
+from django.contrib.auth.models import User
 
 # model for leave
 from django.urls import reverse
@@ -59,3 +60,8 @@ class LeaveApprovingWarden(models.Model):
                               choices=[(hostel_type.name, hostel_type.value) for hostel_type in HostelType],
                               default=HostelType.BH.name)
     authority = models.OneToOneField('users.ApprovingAuthority', related_name='warden', on_delete=CASCADE, null=True)
+
+class Comment(models.Model):
+    user = models.ForeignKey(User,on_delete=models.CASCADE)
+    body = models.TextField()
+    leave_id = models.IntegerField(default=1)

--- a/app/templates/app/leave_detail.html
+++ b/app/templates/app/leave_detail.html
@@ -72,6 +72,63 @@
             </div>
         </div>
     </div>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-md-6 ml-2">
+          <h4>Comment</h4>
+        </div>
+        <div class="col-md-7-offset ml-5 pl-5">
+          <button type="button" class="btn" data-toggle="modal" data-target="#myModal">Add Comment</button>
+        </div>
+      </div>
+
+    {% for c in comments.all %}
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-md-8">
+                <div class="card detail-card">
+                    <div class="card-body">
+                        <div class="card-title" style="font-size: 18px;">
+                            <b>{{ c.user }}</b>
+                        </div>
+                        <p class="card-text">
+                          {{ c.body }}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+    {% endfor %}
+
+
+    <!-- The Modal -->
+    <div class="modal" id="myModal">
+      <div class="modal-dialog modalheight">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4>Comment</h4>
+          </div>
+          <!-- Modal body -->
+          <div class="modal-body">
+            <form class="commentform" id="commentit" method="POST" action="{% url 'app:comment' leave.id %}">
+              {% csrf_token %}
+              <div class="form-group" style="text-align: center;">
+                  <textarea rows='10' cols='50' placeholder='Comment..' name='body'></textarea>
+              </div>
+            </form>
+          </div>
+
+          <!-- Modal footer -->
+          <div class="modal-footer">
+            <a href="javascript:{document.getElementById('commentit').submit()}">
+              <button class="btn btn-block btn-success">Post</button>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <style>
         .detail-card {
             position: relative;

--- a/app/urls.py
+++ b/app/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path('leaves/pending/', views.leaves_pending, name='leaves-pending'),
     path('leaves/past/', views.leaves_past, name='leaves-past'),
     path('leave/<int:pk>/edit/', views.leave_edit, name='leave_edit'),
+    path('leave/<int:pk>/comment/',views.comment,name='comment')
 ]
 if not settings.DEBUG:
     urlpatterns += path('', (r'^static/(?P<path>.*)$', 'django.views.static.serve',

--- a/app/views.py
+++ b/app/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth.forms import PasswordChangeForm
 from app.forms import *
 from app.models import Leave, LeaveApprovingWarden, LeaveApprovingFaculty
 from datetime import datetime
+from .models import Comment
 
 
 def index(request):
@@ -178,18 +179,20 @@ def leave_detail(request, pk):
             'GH': 'Girls Hostel',
             'BH': 'Boys Hostel',
         }
+        comments = Comment.objects.filter(leave_id=pk)
         if user_account.user_type == 'S':
             return render(request, 'app/leave_detail.html', {'leave': leave, 'can_edit': True, 'can_approve': False,
-                                                             'leave_status_values': leave_status_values, 'hostel_type': hostel_type})
+                                                             'leave_status_values': leave_status_values, 'hostel_type': hostel_type,'comments':comments})
         else:
             if user_account.authority.role == 'FAD':
                 return render(request, 'app/leave_detail.html',
                               {'leave': leave, 'can_edit': False, 'can_approve': True, 'is_warden': False,
-                               'leave_status_values': leave_status_values, 'hostel_type': hostel_type})
+                               'leave_status_values': leave_status_values, 'hostel_type': hostel_type,'comments':comments})
             else:
                 return render(request, 'app/leave_detail.html',
                               {'leave': leave, 'can_edit': False, 'can_approve': True, 'is_warden': True,
-                               'leave_status_values': leave_status_values, 'hostel_type': hostel_type})
+                               'leave_status_values': leave_status_values, 'hostel_type': hostel_type,'comments':comments})
+
 
 
 def leave_edit(request, pk):
@@ -255,3 +258,12 @@ def leaves_past(request):
         except:
             leaves = []
         return render(request, 'app/leaves_list.html', {'leaves': leaves, 'can_edit': False, 'leave_status_values': leave_status_values})
+
+def comment(request,pk):
+    if request.method == "POST":
+        comment = Comment()
+        comment.user = request.user
+        comment.body = request.POST['body']
+        comment.leave_id = pk
+        comment.save()
+        return redirect('/leave/' + str(pk) + '/')


### PR DESCRIPTION
Add comment section to the leave_details page, where student and
authority can communicate with each other to solve issues related to
the leave permission.

Fixes #10 

Changes: 5 files are changed namely
- (app/models.py) For adding the Comment Model to store the comments in the database.
- (app/admin.py) For granting access of Comment Model from the Admin Panel.
- (app/urls.py) Adding url for adding a comment.
- (app/views.py) For saving the comment to the database.
- (app/templates/app/leave_detail.html) Adding section for publishing a comment.

Screenshots for the change: 

Changed UI of the leave_details page.

![screenshot 252](https://user-images.githubusercontent.com/29620528/49636680-4d29fa80-fa29-11e8-8fdd-b3eaf080e87e.png)

On clicking the 'Add Comment' button, below modal is popped where currently logged-in user can add comments.

![screenshot 250](https://user-images.githubusercontent.com/29620528/49636706-5e730700-fa29-11e8-818b-b42e17b79fa0.png)

When comment is posted, it appears below the leave details.

![screenshot 251](https://user-images.githubusercontent.com/29620528/49636780-967a4a00-fa29-11e8-8c6a-0fac851daca7.png)

